### PR TITLE
Run jobs and report success of failure

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -16,10 +16,14 @@ GEM
       async (~> 1.14)
     async-pool (0.3.2)
       async (~> 1.25)
+    async-process (1.3.0)
+      async (~> 1.0)
+      async-io (~> 1.0)
     async-websocket (0.16.0)
       async-http (~> 0.51)
       async-io (~> 1.23)
       protocol-websocket (~> 0.7.0)
+    concurrent-ruby (1.1.7)
     console (1.9.0)
     daemons (1.3.1)
     nio4r (2.5.4)
@@ -39,7 +43,9 @@ PLATFORMS
   ruby
 
 DEPENDENCIES
+  async-process
   async-websocket
+  concurrent-ruby
   daemons
 
 BUNDLED WITH

--- a/config/boot.rb
+++ b/config/boot.rb
@@ -29,3 +29,7 @@ lib = File.expand_path('../lib', __dir__)
 $LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
 
 require 'flight_scheduler'
+
+# XXX Move this to a configuration or environment object.
+require 'async'
+Async.logger.debug!

--- a/lib/flight_scheduler.rb
+++ b/lib/flight_scheduler.rb
@@ -27,12 +27,16 @@
 
 module FlightScheduler
   autoload(:Application, 'flight_scheduler/application')
-  autoload(:API, 'flight_scheduler/api')
+  autoload(:MessageProcessor, 'flight_scheduler/message_processor')
+  autoload(:JobRegistry, 'flight_scheduler/job_registry')
+  autoload(:JobRunner, 'flight_scheduler/job_runner')
 
   VERSION = "0.0.1"
 
   def app
-    @app ||= Application.new
+    @app ||= Application.new(
+      job_registry: JobRegistry.new,
+    )
   end
   module_function :app
 end


### PR DESCRIPTION
Respond to requests to run a job on the node, and report back success or
failure. The job is ran using Async::Process and a copy of that process
is maintained in a JobRegistry allowing later access to the process.
This access will allow the job to be cancelled or its status checked.

The subprocess setup is currently limited in a number of ways including:

 * Running the process in the incorrect environment.
 * Not saving the job scripts output.
 * Assuming that the job script exists on the compute node as well as on
   the head node.