### PR TITLE
Job cancellation

### DIFF
--- a/lib/flight_scheduler/job_registry.rb
+++ b/lib/flight_scheduler/job_registry.rb
@@ -53,5 +53,9 @@ module FlightScheduler
     def remove(job_id)
       @jobs.delete(job_id)
     end
+
+    def [](job_id)
+      @jobs[job_id]
+    end
   end
 end

--- a/lib/flight_scheduler/job_runner.rb
+++ b/lib/flight_scheduler/job_runner.rb
@@ -60,5 +60,21 @@ module FlightScheduler
         FlightScheduler.app.job_registry.remove(job_id)
       end
     end
+
+    # Kills the subprocess associated with the given job id if one exists.
+    #
+    # Invariants:
+    #
+    # * Returns an Async::Task that can be `wait`ed on.  When the returned
+    #   task has completed, the subprocess will have been sent a `TERM`
+    #   signal.
+    def cancel_job(job_id)
+      process = FlightScheduler.app.job_registry[job_id]
+      if process && process.running?
+        Async do
+          process.kill
+        end
+      end
+    end
   end
 end

--- a/lib/flight_scheduler/message_processor.rb
+++ b/lib/flight_scheduler/message_processor.rb
@@ -58,6 +58,13 @@ module FlightScheduler
           end
         end
 
+      when 'JOB_CANCELLED'
+        job_id = message[:job_id]
+        Async.logger.info("Cancelling job:#{job_id}")
+        FlightScheduler::JobRunner.cancel_job(job_id)
+        # The JOB_ALLOCATED task will report back that the process has failed.
+        # We don't need to send any messages to the controller here.
+
       else
         Async.logger.info("Unknown message #{message}")
       end

--- a/lib/flight_scheduler/message_processor.rb
+++ b/lib/flight_scheduler/message_processor.rb
@@ -43,15 +43,19 @@ module FlightScheduler
         job_id, script, arguments = message[:job_id], message[:script], message[:arguments]
         Async.logger.info("Running job:#{job_id} script:#{script} arguments:#{arguments}")
         begin
-          FlightScheduler::JobRunner.run_job(job_id, script, *arguments)
+          task = FlightScheduler::JobRunner.run_job(job_id, script, *arguments)
         rescue
           Async.logger.info("Error running job #{job_id} #{$!.message}")
           @connection.write({command: 'NODE_FAILED_JOB', job_id: job_id})
           @connection.flush
         else
-          Async.logger.info("Completed job #{job_id}")
-          @connection.write({command: 'NODE_COMPLETED_JOB', job_id: job_id})
-          @connection.flush
+          Async do
+            status = task.wait
+            Async.logger.info("Completed job #{job_id}")
+            command = status.exitstatus == 0 ? 'NODE_COMPLETED_JOB' : 'NODE_FAILED_JOB'
+            @connection.write({command: command, job_id: job_id})
+            @connection.flush
+          end
         end
 
       else


### PR DESCRIPTION
Cancel running jobs when requested.

The `JobRunner::run_job` method and `MessageProcessor::call` method have been reworked to support 1) processing messages concurrently; 2) more easily ensuring certain invariants are met when processing messages.

`JobRunner::run_job` now has the invariant that the subprocess it creates will be registered with the job registry before it returns.  It returns an `Async::Task`.  `wait`ing on the returned task has the invariant that the subprocess will have been removed from the job registry before `wait` returns.

Those invariants make the implementation of `JobRunner::cancel_job` much simpler.  If the job is still running the subprocess can be retrieved from the job registry and killed.  If the job registry does not contain an entry for the job, it is because the job has already completed.