### PR TITLE
Run the job with the provided environment

### DIFF
--- a/lib/flight_scheduler/job_runner.rb
+++ b/lib/flight_scheduler/job_runner.rb
@@ -51,8 +51,8 @@ module FlightScheduler
     # * Returns an Async::Task that can be `wait`ed on.  When the returned
     #   task has completed, the subprocess has completed and is no longer in
     #   the job registry.
-    def run_job(job_id, *arguments, **options)
-      child = Async::Process::Child.new(*arguments, **options)
+    def run_job(job_id, env, *arguments, **options)
+      child = Async::Process::Child.new(env, *arguments, **options)
       FlightScheduler.app.job_registry.add(job_id, child)
       Async do
         child.wait

--- a/lib/flight_scheduler/message_processor.rb
+++ b/lib/flight_scheduler/message_processor.rb
@@ -45,7 +45,7 @@ module FlightScheduler
         arguments = message[:arguments]
         # Ensure env is indeed a hash otherwise all sorts of weirdness will
         # break loose in Process.spawn
-        env       = message[:environment].to_h
+        env       = message[:environment].map { |k, v| [k.to_s, v&.to_s] }.to_h
 
         Async.logger.info("Running job:#{job_id} script:#{script} arguments:#{arguments}")
         Async.logger.debug("Environment: #{env.map { |k, v| "#{k}=#{v}" }.join("\n")}")


### PR DESCRIPTION
The WS api now provides an `environment` in which to run the command. This is passed through to `Process.spawn` via multiple levels of abstractions. This is why it must be the second argument and a stringified hash. 