### PR TITLE
Redirect stdout and stderr to the specified paths

### DIFF
--- a/lib/flight_scheduler/job_runner.rb
+++ b/lib/flight_scheduler/job_runner.rb
@@ -105,20 +105,22 @@ module FlightScheduler
             'USER' => username,
             'flight_ROOT' => ENV['flight_ROOT'],
           )
+
+          # Write the script_body to disk before we switch user.  We can't
+          # assume that the new user can write to this directory.
+          FileUtils.mkdir_p File.dirname(path)
+          File.write(path, script_body)
+          FileUtils.chmod 0755, path
+
           Process::Sys.setgid(passwd.gid)
           Process::Sys.setuid(username)
           Process.setsid
 
           # Create the stdout/stderr directories
-          stdout_path = File.expand_path(stdout, '~')
-          stderr_path = File.expand_path(stderr, '~')
+          stdout_path = File.expand_path(stdout, passwd.dir)
+          stderr_path = File.expand_path(stderr, passwd.dir)
           FileUtils.mkdir_p File.dirname(stdout_path)
           FileUtils.mkdir_p File.dirname(stderr_path)
-
-          # Write the script_body to disk
-          FileUtils.mkdir_p File.dirname(path)
-          File.write(path, script_body)
-          FileUtils.chmod 0755, path
 
           # Build the options hash
           opts = { unsetenv_others: true }

--- a/lib/flight_scheduler/message_processor.rb
+++ b/lib/flight_scheduler/message_processor.rb
@@ -45,11 +45,13 @@ module FlightScheduler
         arguments = message[:arguments]
         env       = message[:environment]
         username  = message[:username]
+        stdout    = message[:stdout_path]
+        stderr    = message[:stderr_path]
 
         Async.logger.info("Running job:#{job_id} script:#{script} arguments:#{arguments}")
         Async.logger.debug("Environment: #{env.map { |k, v| "#{k}=#{v}" }.join("\n")}")
         begin
-          job = FlightScheduler::JobRunner.new(job_id, env, script, arguments, username)
+          job = FlightScheduler::JobRunner.new(job_id, env, script, arguments, username, stdout, stderr)
           job.run
         rescue
           Async.logger.info("Error running job #{job_id} #{$!.message}")

--- a/spec/job_runner_spec.rb
+++ b/spec/job_runner_spec.rb
@@ -40,7 +40,9 @@ RSpec.describe FlightScheduler::JobRunner do
   let(:arguments) { [] }
 
   subject do
-    described_class.new(job_id, env, script_body, arguments, Etc.getlogin)
+    described_class.new(
+      job_id, env, script_body, arguments, Etc.getlogin, '/tmp/foo', '/tmp/foo'
+    )
   end
 
   it { should be_valid }


### PR DESCRIPTION
The allocation message now contains paths to redirect `stdout` and `stderr` to. These paths will always be included so a default is not required.

Currently the working directory is always `/` which makes handling relative paths inconvenient. Instead relative paths are expanded from the user's home directory. This can be revisited at some future point.