### PR TITLE
Become the requested user before running the job

### DIFF
--- a/lib/flight_scheduler.rb
+++ b/lib/flight_scheduler.rb
@@ -26,6 +26,7 @@
 #==============================================================================
 
 require "active_support/string_inquirer"
+require 'flight_scheduler/errors'
 
 module FlightScheduler
   autoload(:Application, 'flight_scheduler/application')

--- a/lib/flight_scheduler/errors.rb
+++ b/lib/flight_scheduler/errors.rb
@@ -26,6 +26,6 @@
 #==============================================================================
 
 module FlightScheduler
-  class BaseErrors < RuntimeError; end
+  class BaseError < RuntimeError; end
   class JobValidationError < BaseError; end
 end

--- a/lib/flight_scheduler/job_runner.rb
+++ b/lib/flight_scheduler/job_runner.rb
@@ -38,7 +38,7 @@ module FlightScheduler
   # * The job's standard and error output is not saved to disk.
   #
   JobRunner = Struct.new(:id, :envs, :script_body, :arguments) do
-    attr_accessor :child, :task, :status
+    attr_accessor :child_pid, :task, :status
 
     extend Forwardable
     def_delegator :task, :wait
@@ -83,36 +83,39 @@ module FlightScheduler
       path = script_path.to_path
       FlightScheduler.app.job_registry.add(id, self)
 
-      self.task = Async do
-        # Write the script_body to disk
-        FileUtils.mkdir_p File.dirname(path)
-        Async::IO::Stream.open(path, 'w') do |stream|
-          stream.write(script_body)
-        end
-        FileUtils.chmod 0755, path
+      self.task = Async do |task|
+        # Fork to create the child process [Non Blocking]
+        self.child_pid = Kernel.fork do
+          # Write the script_body to disk
+          FileUtils.mkdir_p File.dirname(path)
+          File.write(path, script_body)
+          FileUtils.chmod 0755, path
 
-        # Starts the child process
-        self.child = Async::Process::Child.new(string_envs, path, *arguments, unsetenv_others: true)
-        self.status = self.child.wait
+          # Exec into the job command
+          Kernel.exec(string_envs, path, *arguments, unsetenv_others: true)
+        end
+
+        # Loop asynchronously until the child is finished
+        until out = Process.wait2(child_pid, Process::WNOHANG) do
+          task.yield
+        end
+        self.status = out.last
+
+        # Reset the child_pid, this prevents cancel killing other processes
+        # which might spawn with the same PID
+        self.child_pid = nil
       ensure
         FlightScheduler.app.job_registry.remove(id)
         FileUtils.rm_rf File.dirname(path)
       end
     end
 
-    # Kills the subprocess associated with the given job id if one exists.
-    #
-    # Invariants:
-    #
-    # * Returns an Async::Task that can be `wait`ed on.  When the returned
-    #   task has completed, the subprocess will have been sent a `TERM`
-    #   signal.
+    # Kills the associated subprocess
     def cancel
-      if child && child.running?
-        Async do
-          child.kill
-        end
-      end
+      return unless child_pid
+      Kernel.kill('SIGTERM', self.child_pid)
+    rescue Errno::ESRCH
+      # NOOP - Don't worry if the process has already finished
     end
   end
 end

--- a/lib/flight_scheduler/message_processor.rb
+++ b/lib/flight_scheduler/message_processor.rb
@@ -44,11 +44,12 @@ module FlightScheduler
         script    = message[:script]
         arguments = message[:arguments]
         env       = message[:environment]
+        username  = message[:username]
 
         Async.logger.info("Running job:#{job_id} script:#{script} arguments:#{arguments}")
         Async.logger.debug("Environment: #{env.map { |k, v| "#{k}=#{v}" }.join("\n")}")
         begin
-          job = FlightScheduler::JobRunner.new(job_id, env, script, arguments)
+          job = FlightScheduler::JobRunner.new(job_id, env, script, arguments, username)
           job.run
         rescue
           Async.logger.info("Error running job #{job_id} #{$!.message}")

--- a/spec/job_runner_spec.rb
+++ b/spec/job_runner_spec.rb
@@ -40,7 +40,7 @@ RSpec.describe FlightScheduler::JobRunner do
   let(:arguments) { [] }
 
   subject do
-    described_class.new(job_id, env, script_body, arguments)
+    described_class.new(job_id, env, script_body, arguments, Etc.getlogin)
   end
 
   it { should be_valid }


### PR DESCRIPTION
The submission now includes a `username` the job needs to be executed as. This is looked up from `passwd` and the relevant changes are made in the environment.

The `daemon` needs to `fork` a child process so it can modify the environment without affecting other jobs. This means the existing `Async::IO::Stream` work had to be removed as it isn't compatible. It has been replaced with `Kernel.fork` as it is non blocking. This allows for `daemon` to preform on asynchronous non-blocking wait on the child.

The asynchronous writing of the script has been removed as its now done in the child process. The asynchronous block in `cancel` has also been removed as it's not being used and the sending SIGTERM is a fast operation.