### PR TITLE
Allocation execution separation

### DIFF
--- a/lib/flight_scheduler.rb
+++ b/lib/flight_scheduler.rb
@@ -30,12 +30,14 @@ require 'flight_scheduler/errors'
 
 module FlightScheduler
   autoload(:Application, 'flight_scheduler/application')
+  autoload(:BatchScript, 'flight_scheduler/batch_script')
   autoload(:Configuration, 'flight_scheduler/configuration')
   autoload(:Job, 'flight_scheduler/job')
   autoload(:JobRegistry, 'flight_scheduler/job_registry')
   autoload(:JobRunner, 'flight_scheduler/job_runner')
+  autoload(:JobStep, 'flight_scheduler/job_step')
+  autoload(:JobStepRunner, 'flight_scheduler/job_step_runner')
   autoload(:MessageProcessor, 'flight_scheduler/message_processor')
-  autoload(:SubmissionScript, 'flight_scheduler/submission_script')
 
   VERSION = "0.0.1"
 

--- a/lib/flight_scheduler.rb
+++ b/lib/flight_scheduler.rb
@@ -31,6 +31,7 @@ require 'flight_scheduler/errors'
 module FlightScheduler
   autoload(:Application, 'flight_scheduler/application')
   autoload(:Configuration, 'flight_scheduler/configuration')
+  autoload(:Job, 'flight_scheduler/job')
   autoload(:JobRegistry, 'flight_scheduler/job_registry')
   autoload(:JobRunner, 'flight_scheduler/job_runner')
   autoload(:MessageProcessor, 'flight_scheduler/message_processor')

--- a/lib/flight_scheduler.rb
+++ b/lib/flight_scheduler.rb
@@ -35,6 +35,7 @@ module FlightScheduler
   autoload(:JobRegistry, 'flight_scheduler/job_registry')
   autoload(:JobRunner, 'flight_scheduler/job_runner')
   autoload(:MessageProcessor, 'flight_scheduler/message_processor')
+  autoload(:SubmissionScript, 'flight_scheduler/submission_script')
 
   VERSION = "0.0.1"
 

--- a/lib/flight_scheduler.rb
+++ b/lib/flight_scheduler.rb
@@ -34,7 +34,7 @@ module FlightScheduler
   autoload(:Configuration, 'flight_scheduler/configuration')
   autoload(:Job, 'flight_scheduler/job')
   autoload(:JobRegistry, 'flight_scheduler/job_registry')
-  autoload(:JobRunner, 'flight_scheduler/job_runner')
+  autoload(:BatchScriptRunner, 'flight_scheduler/batch_script_runner')
   autoload(:JobStep, 'flight_scheduler/job_step')
   autoload(:JobStepRunner, 'flight_scheduler/job_step_runner')
   autoload(:MessageProcessor, 'flight_scheduler/message_processor')

--- a/lib/flight_scheduler/batch_script.rb
+++ b/lib/flight_scheduler/batch_script.rb
@@ -67,7 +67,7 @@ module FlightScheduler
     def write
       # Write the script_body to disk
       FileUtils.mkdir_p(File.dirname(path))
-      File.write(path, script_body)
+      File.write(path, @script_body)
       FileUtils.chmod(0755, path)
     end
 

--- a/lib/flight_scheduler/batch_script.rb
+++ b/lib/flight_scheduler/batch_script.rb
@@ -26,7 +26,7 @@
 #==============================================================================
 
 module FlightScheduler
-  class SubmissionScript
+  class BatchScript
 
     attr_reader :job, :arguments
 

--- a/lib/flight_scheduler/batch_script_runner.rb
+++ b/lib/flight_scheduler/batch_script_runner.rb
@@ -68,7 +68,7 @@ module FlightScheduler
       end
 
       FlightScheduler.app.job_registry.add_runner(@job.id, 'BATCH', self)
-      @task = Async do
+      @task = Async do |task|
         # Fork to create the child process [Non Blocking]
         @child_pid = Kernel.fork do
           # Write the script_body to disk before we switch user.  We can't
@@ -98,7 +98,7 @@ module FlightScheduler
 
         # Loop asynchronously until the child is finished
         until out = Process.wait2(@child_pid, Process::WNOHANG) do
-          @task.yield
+          task.yield
         end
         @status = out.last
 
@@ -107,7 +107,7 @@ module FlightScheduler
         @child_pid = nil
       ensure
         FlightScheduler.app.job_registry.remove_runner(@job.id, 'BATCH')
-        @job.remove_script
+        @script.remove
       end
     end
 

--- a/lib/flight_scheduler/batch_script_runner.rb
+++ b/lib/flight_scheduler/batch_script_runner.rb
@@ -107,6 +107,7 @@ module FlightScheduler
         @child_pid = nil
       ensure
         FlightScheduler.app.job_registry.remove_runner(@job.id, 'BATCH')
+        FlightScheduler.app.job_registry.remove_job(@job.id)
         @script.remove
       end
     end

--- a/lib/flight_scheduler/batch_script_runner.rb
+++ b/lib/flight_scheduler/batch_script_runner.rb
@@ -114,7 +114,7 @@ module FlightScheduler
     # Kills the associated subprocess
     def cancel
       return unless @child_pid
-      Kernel.kill('SIGTERM', @child_pid)
+      Process.kill('SIGTERM', @child_pid)
     rescue Errno::ESRCH
       # NOOP - Don't worry if the process has already finished
     end

--- a/lib/flight_scheduler/job.rb
+++ b/lib/flight_scheduler/job.rb
@@ -25,11 +25,12 @@
 # https://github.com/openflighthpc/flight-scheduler-daemon
 #==============================================================================
 
+require 'etc'
+
 module FlightScheduler
   class Job
 
     attr_reader :id, :username
-    attr_accessor :script
 
     def initialize(id, env, username)
       @id = id

--- a/lib/flight_scheduler/job.rb
+++ b/lib/flight_scheduler/job.rb
@@ -48,7 +48,7 @@ module FlightScheduler
     end
 
     def env
-      stringified = super.map { |k, v| [k.to_s, v] }.to_h
+      stringified = @env.map { |k, v| [k.to_s, v] }.to_h
       stringified.merge(
         'HOME' => home_dir,
         'LOGNAME' => username,

--- a/lib/flight_scheduler/job.rb
+++ b/lib/flight_scheduler/job.rb
@@ -1,0 +1,105 @@
+#==============================================================================
+# Copyright (C) 2020-present Alces Flight Ltd.
+#
+# This file is part of FlightSchedulerDaemon.
+#
+# This program and the accompanying materials are made available under
+# the terms of the Eclipse Public License 2.0 which is available at
+# <https://www.eclipse.org/legal/epl-2.0>, or alternative license
+# terms made available by Alces Flight Ltd - please direct inquiries
+# about licensing to licensing@alces-flight.com.
+#
+# FlightSchedulerDaemon is distributed in the hope that it will be useful, but
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, EITHER EXPRESS OR
+# IMPLIED INCLUDING, WITHOUT LIMITATION, ANY WARRANTIES OR CONDITIONS
+# OF TITLE, NON-INFRINGEMENT, MERCHANTABILITY OR FITNESS FOR A
+# PARTICULAR PURPOSE. See the Eclipse Public License 2.0 for more
+# details.
+#
+# You should have received a copy of the Eclipse Public License 2.0
+# along with FlightSchedulerDaemon. If not, see:
+#
+#  https://opensource.org/licenses/EPL-2.0
+#
+# For more information on FlightSchedulerDaemon, please visit:
+# https://github.com/openflighthpc/flight-scheduler-daemon
+#==============================================================================
+
+module FlightScheduler
+  class Job
+
+    attr_reader :id, :script_body, :arguments, :username
+
+    def initialize(id, env, script_body, arguments, username, stdout_path, stderr_path)
+      @id = id
+      @env = env
+      @script_body = script_body
+      @arguments = arguments
+      @username = username
+    end
+
+    def path
+      FlightScheduler.app.config.spool_dir.join('state', id, 'job-script').to_path
+    end
+
+    # Checks the various parameters are in the correct format before running
+    # This is to prevent rogue data being passed Process.spawn or rm -f
+    def valid?
+      return false unless /\A[\w-]+\Z/.match? id
+      return false unless env.is_a? Hash
+      return false unless arguments.is_a? Array
+      return false unless passwd
+      return false if stdout_path.to_s.empty?
+      return false if stderr_path.to_s.empty?
+      true
+    end
+
+    def env
+      stringified = super.map { |k, v| [k.to_s, v] }.to_h
+      stringified.merge(
+        'HOME' => home_dir,
+        'LOGNAME' => username,
+        'PATH' => '/bin:/sbin:/usr/bin:/usr/sbin',
+        'USER' => username,
+        'flight_ROOT' => ENV['flight_ROOT'],
+      )
+    end
+
+    def home_dir
+      passwd.dir
+    end
+
+    def working_dir
+      home_dir
+    end
+
+    def gid
+      passwd.gid
+    end
+
+    def stdout_path
+      File.expand_path(@stdout_path, home_dir)
+    end
+
+    def stderr_path 
+      File.expand_path(@stderr_path, home_dir)
+    end
+
+    def write_script
+      # Write the script_body to disk
+      FileUtils.mkdir_p(File.dirname(path))
+      File.write(path, script_body)
+      FileUtils.chmod(0755, path)
+    end
+
+    def remove_script
+      FileUtils.rm_rf(File.dirname(path))
+    end
+
+    def passwd
+      @passwd ||= Etc.getpwnam(username)
+    rescue ArgumentError
+      # NOOP - The user can not be found, this is handled in valid?
+    end
+  end
+end

--- a/lib/flight_scheduler/job_runner.rb
+++ b/lib/flight_scheduler/job_runner.rb
@@ -66,7 +66,7 @@ module FlightScheduler
         ERROR
       end
 
-      FlightScheduler.app.job_registry.add(id, self)
+      FlightScheduler.app.job_registry.add_runner(@job.id, 'BATCH', self)
       @task = Async do
         # Fork to create the child process [Non Blocking]
         @child_pid = Kernel.fork do
@@ -106,7 +106,7 @@ module FlightScheduler
         # which might spawn with the same PID
         @child_pid = nil
       ensure
-        FlightScheduler.app.job_registry.remove(@job.id)
+        FlightScheduler.app.job_registry.remove_runner(@job.id, 'BATCH')
         @job.remove_script
       end
     end

--- a/lib/flight_scheduler/message_processor.rb
+++ b/lib/flight_scheduler/message_processor.rb
@@ -55,13 +55,13 @@ module FlightScheduler
         end
 
       when 'RUN_SCRIPT'
-        arguments = message[:arguments]
-        job_id    = message[:job_id]
-        script    = message[:script]
-        stderr    = message[:stderr_path]
-        stdout    = message[:stdout_path]
+        arguments   = message[:arguments]
+        job_id      = message[:job_id]
+        script_body = message[:script]
+        stderr      = message[:stderr_path]
+        stdout      = message[:stdout_path]
 
-        Async.logger.debug("Running script for job:#{job_id} script:#{script} arguments:#{arguments}")
+        Async.logger.debug("Running script for job:#{job_id} script:#{script_body} arguments:#{arguments}")
         error_handler = lambda do
           Async.logger.info("Error running script job:#{job_id} #{$!.message}")
           if message[:array_job_id]
@@ -77,8 +77,8 @@ module FlightScheduler
         end
         begin
           job = FlightScheduler.app.job_registry.lookup_job(job_id)
-          job.script = BatchScript.new(job, script, arguments, stdout, stderr)
-          runner = FlightScheduler::JobRunner.new(job)
+          script = BatchScript.new(job, script_body, arguments, stdout, stderr)
+          runner = FlightScheduler::BatchScriptRunner.new(script)
           runner.run
         rescue
           error_handler.call

--- a/lib/flight_scheduler/message_processor.rb
+++ b/lib/flight_scheduler/message_processor.rb
@@ -41,24 +41,29 @@ module FlightScheduler
 
       when 'JOB_ALLOCATED'
         job_id    = message[:job_id]
-        script    = message[:script]
-        arguments = message[:arguments]
         env       = message[:environment]
         username  = message[:username]
-        stdout    = message[:stdout_path]
-        stderr    = message[:stderr_path]
 
-        Async.logger.info("Running job:#{job_id} script:#{script} arguments:#{arguments}")
         Async.logger.debug("Environment: #{env.map { |k, v| "#{k}=#{v}" }.join("\n")}")
         begin
           job = FlightScheduler::Job.new(job_id, env, username)
-          if script
-            job.script = SubmissionScript.new(job, script, arguments, stdout, stderr)
-            runner = FlightScheduler::JobRunner.new(job)
-            runner.run
-          end
+          FlightScheduler.app.job_registry.add_job(job.id, job)
         rescue
-          Async.logger.info("Error running job #{job_id} #{$!.message}")
+          Async.logger.info("Error configuring job #{job_id} #{$!.message}")
+          @connection.write({command: 'JOB_ALLOCATION_FAILED', job_id: job_id})
+          @connection.flush
+        end
+
+      when 'RUN_SCRIPT'
+        arguments = message[:arguments]
+        job_id    = message[:job_id]
+        script    = message[:script]
+        stderr    = message[:stderr_path]
+        stdout    = message[:stdout_path]
+
+        Async.logger.debug("Running script for job:#{job_id} script:#{script} arguments:#{arguments}")
+        error_handler = lambda do
+          Async.logger.info("Error running script job:#{job_id} #{$!.message}")
           if message[:array_job_id]
             @connection.write({
               command: 'NODE_FAILED_ARRAY_TASK',
@@ -69,33 +74,41 @@ module FlightScheduler
             @connection.write({command: 'NODE_FAILED_JOB', job_id: job_id})
           end
           @connection.flush
+        end
+        begin
+          job = FlightScheduler.app.job_registry.lookup_job(job_id)
+          job.script = SubmissionScript.new(job, script, arguments, stdout, stderr)
+          runner = FlightScheduler::JobRunner.new(job)
+          runner.run
+        rescue
+          error_handler.call
         else
-          unless job.script.nil?
-            Async do
-              runner.wait
-              Async.logger.info("Completed job #{job_id}")
-              if message[:array_job_id]
-                command = runner.success? ?
-                  'NODE_COMPLETED_ARRAY_TASK' :
-                  'NODE_FAILED_ARRAY_TASK'
-                @connection.write({
-                  command: command,
-                  array_job_id: message[:array_job_id],
-                  array_task_id: message[:array_task_id],
-                })
-              else
-                command = runner.success? ? 'NODE_COMPLETED_JOB' : 'NODE_FAILED_JOB'
-                @connection.write({command: command, job_id: job_id})
-              end
-              @connection.flush
+          Async do
+            runner.wait
+            Async.logger.info("Completed job #{job_id}")
+            if message[:array_job_id]
+              command = runner.success? ?
+                'NODE_COMPLETED_ARRAY_TASK' :
+                'NODE_FAILED_ARRAY_TASK'
+              @connection.write({
+                command: command,
+                array_job_id: message[:array_job_id],
+                array_task_id: message[:array_task_id],
+              })
+            else
+              command = runner.success? ? 'NODE_COMPLETED_JOB' : 'NODE_FAILED_JOB'
+              @connection.write({command: command, job_id: job_id})
             end
+            @connection.flush
+          rescue
+            error_handler.call
           end
         end
 
       when 'JOB_CANCELLED'
         job_id = message[:job_id]
         Async.logger.info("Cancelling job:#{job_id}")
-        job_runner = FlightScheduler.app.job_registry[job_id]
+        job_runner = FlightScheduler.app.job_registry.lookup_runner(job_id, 'BATCH')
         job_runner.cancel if job_runner
         # The JOB_ALLOCATED task will report back that the process has failed.
         # We don't need to send any messages to the controller here.

--- a/lib/flight_scheduler/message_processor.rb
+++ b/lib/flight_scheduler/message_processor.rb
@@ -77,7 +77,7 @@ module FlightScheduler
         end
         begin
           job = FlightScheduler.app.job_registry.lookup_job(job_id)
-          job.script = SubmissionScript.new(job, script, arguments, stdout, stderr)
+          job.script = BatchScript.new(job, script, arguments, stdout, stderr)
           runner = FlightScheduler::JobRunner.new(job)
           runner.run
         rescue

--- a/lib/flight_scheduler/message_processor.rb
+++ b/lib/flight_scheduler/message_processor.rb
@@ -109,9 +109,12 @@ module FlightScheduler
         job_id = message[:job_id]
         Async.logger.info("Cancelling job:#{job_id}")
         job_runner = FlightScheduler.app.job_registry.lookup_runner(job_id, 'BATCH')
-        job_runner.cancel if job_runner
-        # The JOB_ALLOCATED task will report back that the process has failed.
-        # We don't need to send any messages to the controller here.
+        if job_runner
+          job_runner.cancel
+          # The RUN_SCRIPT task will report back that the process has failed.
+          # We don't need to send any messages to the controller here.
+        end
+        FlightScheduler.app.job_registry.remove_job(job_id)
 
       else
         Async.logger.info("Unknown message #{message}")

--- a/spec/batch_script_runner_spec.rb
+++ b/spec/batch_script_runner_spec.rb
@@ -28,7 +28,7 @@
 require 'spec_helper'
 require 'securerandom'
 
-RSpec.describe FlightScheduler::JobRunner do
+RSpec.describe FlightScheduler::BatchScriptRunner do
   let(:job_id) { SecureRandom.uuid }
   let(:env) { {} }
   let(:script_body) do


### PR DESCRIPTION
This PR separates resource allocation from running the submission script on the allocated resources.  The motivation for this change is to support interactive jobs and job steps.

See https://github.com/openflighthpc/flight-scheduler-controller/pull/20 for the related controller changes.

Previously, the daemon received a single command to run setup a job and run its batch script.  Once the batch script completed, the details for running it, e.g., username, environment, were lost.  This prevented additional steps being ran for the job including interactive steps.  This PR separates setting up a Job from running its batch script.

When a node is allocated, the `JOB_ALLOCATED` command is recieved and a reference to the `Job` is stored.  This required extracting a `Job` model from `JobRunner`.  If a `RUN_SCRIPT` command is received, the script specified in that command is executed.  The stored reference to the `Job` is retrieved and used to setup the execution context for the script.

Once the batch script has completed, the reference to the job is removed as no further steps against that job are supported.  If a job does not have a batch script, the only way to remove the reference to the job is to cancel it.

As a job may not have a batch script, details of the batch script have been moved from `Job`/`JobRunner` to a new model `BatchScript`.
