### PR TITLE
Do not update the JobRegistry on JOB_CANCELLED

### DIFF
--- a/lib/flight_scheduler/message_processor.rb
+++ b/lib/flight_scheduler/message_processor.rb
@@ -108,14 +108,11 @@ module FlightScheduler
       when 'JOB_CANCELLED'
         job_id = message[:job_id]
         Async.logger.info("Cancelling job:#{job_id}")
-        job_runner = FlightScheduler.app.job_registry.lookup_runner(job_id, 'BATCH')
-        if job_runner
-          job_runner.cancel
-          # The RUN_SCRIPT task will report back that the process has failed.
-          # We don't need to send any messages to the controller here.
-        end
-        FlightScheduler.app.job_registry.remove_job(job_id)
-
+        FlightScheduler.app.job_registry.lookup_runner(job_id, 'BATCH')&.cancel
+        # The RUN_SCRIPT task will report back that the process has failed.
+        # NOTE: The job is not removed here from the registry here as it *may*
+        #       not have finished. This allows for a subsequent cancellation request.
+        #       The job runner will preform the cleanup once the process has ended
       else
         Async.logger.info("Unknown message #{message}")
       end


### PR DESCRIPTION
There are few problems with the previous implementation:

1. It did not correctly cleanup the `job_registry` as both the `job` and the `runner` need to be removed,
2. It incorrectly assumes that `SIGTERM` will terminate the process (it might not - it could be caught), and
3. The `BatchRunner` (insert other class) is still waiting on the child process to exit and will preform the cleanup.

Instead `JOB_CANCELLED` event should fire and forget the `SIGTERM` and leave the registry intact. This way the job is only removed after the process has actually finished.

NOTE: The scheduler still assumes a `JOB_CANCELLED` message is guaranteed to end the process. This still needs to be addressed.