### PR TITLE
Release the allocation when `JOB_DEALLOCATED` is received 

### DIFF
--- a/lib/flight_scheduler.rb
+++ b/lib/flight_scheduler.rb
@@ -38,6 +38,7 @@ module FlightScheduler
   autoload(:JobStep, 'flight_scheduler/job_step')
   autoload(:JobStepRunner, 'flight_scheduler/job_step_runner')
   autoload(:MessageProcessor, 'flight_scheduler/message_processor')
+  autoload(:MessageSender, 'flight_scheduler/message_sender')
 
   VERSION = "0.0.1"
 

--- a/lib/flight_scheduler/application.rb
+++ b/lib/flight_scheduler/application.rb
@@ -67,7 +67,7 @@ module FlightScheduler
           Async::WebSocket::Client.connect(endpoint) do |connection|
             Async.logger.info("Connected to #{controller_url.inspect}")
             @connection = connection
-            processor = MessageProcessor.new(connection)
+            processor = MessageProcessor.new
             connection.write({ command: "CONNECTED", node: node })
             connection.flush
             while message = connection.read

--- a/lib/flight_scheduler/application.rb
+++ b/lib/flight_scheduler/application.rb
@@ -48,6 +48,14 @@ module FlightScheduler
       @root ||= Pathname.new(__dir__).join('../../').expand_path
     end
 
+    def connection
+      if @connection && @connection.closed?
+        nil
+      elsif @connection
+        @connection
+      end
+    end
+
     def run
       Async do |task|
         controller_url = FlightScheduler.app.config.controller_url
@@ -58,6 +66,7 @@ module FlightScheduler
           Async.logger.info("Connecting to #{controller_url.inspect}")
           Async::WebSocket::Client.connect(endpoint) do |connection|
             Async.logger.info("Connected to #{controller_url.inspect}")
+            @connection = connection
             processor = MessageProcessor.new(connection)
             connection.write({ command: "CONNECTED", node: node })
             connection.flush

--- a/lib/flight_scheduler/batch_script_runner.rb
+++ b/lib/flight_scheduler/batch_script_runner.rb
@@ -107,7 +107,6 @@ module FlightScheduler
         @child_pid = nil
       ensure
         FlightScheduler.app.job_registry.remove_runner(@job.id, 'BATCH')
-        FlightScheduler.app.job_registry.remove_job(@job.id)
         @script.remove
       end
     end

--- a/lib/flight_scheduler/job_registry.rb
+++ b/lib/flight_scheduler/job_registry.rb
@@ -56,7 +56,7 @@ module FlightScheduler
     def add_runner(job_id, runner_id, runner)
       data = @jobs[job_id]
       raise UnknownJob, job_id if data.nil?
-      raise FrozenJob, job_id if data[:deallocated]
+      raise DeallocatedJob, job_id if data[:deallocated]
       runners = data[:runners]
       if runners[runner_id]
         raise DuplicateRunner, runner_id

--- a/lib/flight_scheduler/job_registry.rb
+++ b/lib/flight_scheduler/job_registry.rb
@@ -81,6 +81,11 @@ module FlightScheduler
       lookup_job(job_id) or raise UnknownJob, job_id
     end
 
+    def lookup_runners(job_id)
+      data = @jobs[job_id]
+      data.nil? ? [] : data[:runners].to_a.flatten
+    end
+
     def lookup_runner(job_id, runner_id)
       data = @jobs[job_id]
       data.nil? ? nil : data[:runners][runner_id]

--- a/lib/flight_scheduler/job_step_runner.rb
+++ b/lib/flight_scheduler/job_step_runner.rb
@@ -107,7 +107,7 @@ module FlightScheduler
         @child_pid = nil
       ensure
         FlightScheduler.app.job_registry.remove_runner(@job.id, @step.id)
-        input_pipe.close
+        input_pipe&.close
       end
     end
 

--- a/lib/flight_scheduler/message_processor.rb
+++ b/lib/flight_scheduler/message_processor.rb
@@ -158,7 +158,7 @@ module FlightScheduler
           end
 
           # Wait for the runners to finish and remove the job
-          task.yield until FlightScheduler.app.job_registry.lookup_runners(job_id).empty?
+          task.sleep(0.1) until FlightScheduler.app.job_registry.lookup_runners(job_id).empty?
           FlightScheduler.app.job_registry.remove_job(job_id)
           MessageSender.send(command: 'NODE_DEALLOCATED', job_id: job_id)
         end
@@ -172,7 +172,7 @@ module FlightScheduler
 
         # Report back when all the runners have stop
         Async do |task|
-          task.yield until FlightScheduler.app.job_registry.lookup_runners(job_id).empty?
+          task.sleep(0.1) until FlightScheduler.app.job_registry.lookup_runners(job_id).empty?
           FlightScheduler.app.job_registry.remove_job(job_id)
           MessageSender.send(command: 'NODE_DEALLOCATED', job_id: job_id)
         end

--- a/lib/flight_scheduler/message_processor.rb
+++ b/lib/flight_scheduler/message_processor.rb
@@ -159,10 +159,10 @@ module FlightScheduler
         end
 
       when 'JOB_DEALLOCATED'
+        job_id = message[:job_id]
         Async.logger.info("Deallocating job:#{job_id}")
 
         # Remove the job to prevent any further job steps
-        job_id = message[:job_id]
         FlightScheduler.app.job_registry.remove_job(job_id)
 
         # Report back when all the runners have stop

--- a/lib/flight_scheduler/message_processor.rb
+++ b/lib/flight_scheduler/message_processor.rb
@@ -141,10 +141,10 @@ module FlightScheduler
         end
 
       when 'JOB_CANCELLED'
+        job_id = message[:job_id]
         Async.logger.info("Cancelling job:#{job_id}")
 
         # Deallocate the job to prevent any further job steps
-        job_id = message[:job_id]
         FlightScheduler.app.job_registry.deallocate_job(job_id)
 
         Async do |task|

--- a/lib/flight_scheduler/message_processor.rb
+++ b/lib/flight_scheduler/message_processor.rb
@@ -181,9 +181,9 @@ module FlightScheduler
         Async.logger.info("Unknown message #{message}")
       end
       Async.logger.debug("Processed message #{message.inspect}")
-    rescue => e
+    rescue
       Async.logger.warn("Error processing message #{$!.message}")
-      Async.logger.debug e.full_message
+      Async.logger.debug $!.full_message
     end
   end
 end

--- a/lib/flight_scheduler/message_processor.rb
+++ b/lib/flight_scheduler/message_processor.rb
@@ -30,6 +30,9 @@ module FlightScheduler
   # Process incoming messages and send responses.
   #
   class MessageProcessor
+    # TODO: Remove the particular instance of connection as it might drop out
+    # during long running operations. Instead use MessageSender which polls for
+    # the currently open connection
     def initialize(connection)
       @connection = connection
     end

--- a/lib/flight_scheduler/message_processor.rb
+++ b/lib/flight_scheduler/message_processor.rb
@@ -133,7 +133,7 @@ module FlightScheduler
             Async.logger.info("Completed step for job #{job_id}")
             Async.logger.debug("Output: #{runner.output}")
             command = runner.success? ? 'RUN_STEP_COMPLETED' : 'RUN_STEP_FAILED'
-            @connection.write({command: command, job_id: job_id})
+            @connection.write({command: command, job_id: job_id, step_id: step_id})
             @connection.flush
           rescue
             error_handler.call

--- a/lib/flight_scheduler/message_sender.rb
+++ b/lib/flight_scheduler/message_sender.rb
@@ -48,7 +48,7 @@ module FlightScheduler
         # Wait until a connection becomes available
         connection = nil
         until connection = FlightScheduler.app.connection
-          task.yield
+          task.sleep(0.1)
         end
 
         # Send the message

--- a/lib/flight_scheduler/message_sender.rb
+++ b/lib/flight_scheduler/message_sender.rb
@@ -1,0 +1,62 @@
+#==============================================================================
+# Copyright (C) 2020-present Alces Flight Ltd.
+#
+# This file is part of FlightSchedulerDaemon.
+#
+# This program and the accompanying materials are made available under
+# the terms of the Eclipse Public License 2.0 which is available at
+# <https://www.eclipse.org/legal/epl-2.0>, or alternative license
+# terms made available by Alces Flight Ltd - please direct inquiries
+# about licensing to licensing@alces-flight.com.
+#
+# FlightSchedulerDaemon is distributed in the hope that it will be useful, but
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, EITHER EXPRESS OR
+# IMPLIED INCLUDING, WITHOUT LIMITATION, ANY WARRANTIES OR CONDITIONS
+# OF TITLE, NON-INFRINGEMENT, MERCHANTABILITY OR FITNESS FOR A
+# PARTICULAR PURPOSE. See the Eclipse Public License 2.0 for more
+# details.
+#
+# You should have received a copy of the Eclipse Public License 2.0
+# along with FlightSchedulerDaemon. If not, see:
+#
+#  https://opensource.org/licenses/EPL-2.0
+#
+# For more information on FlightSchedulerDaemon, please visit:
+# https://github.com/openflighthpc/flight-scheduler-daemon
+#==============================================================================
+
+module FlightScheduler
+  class MessageSender
+    def self.send(**opts)
+      new(**opts).tap(&:write)
+    end
+
+    attr_reader :opts, :task
+
+    def initialize(**opts)
+      @opts = opts
+    end
+
+    def wait
+      task.wait
+    end
+
+    def write
+      Async do |t|
+        @task = t
+
+        # Wait until a connection becomes available
+        connection = nil
+        until connection = FlightScheduler.app.connection
+          task.yield
+        end
+
+        # Send the message
+        connection.write(**opts)
+
+        # Flush the message
+        connection.flush
+      end
+    end
+  end
+end


### PR DESCRIPTION
Previously the allocation wouldn't be released by secondary daemons within a batch allocation. To fix this, the allocation must be explicitly released on all nodes. This means the `NODE_COMPLETE_JOB`, `NODE_FAILED_JOB`, (etc ..) no longer release the allocation or the job.

The `JOB _DEALLOCATED` message is similar to `JOB_CANCELLED` however it does not send `SIGTERM`. Both messages will cause the daemon to wait for all job runners to finish. The daemon then removes the job from the registry and responds `NODE_DEALLOCATED`.

Jobs which receive a deallocation/cancel message are flagged ad `deallocated` within the job registry. This prevents any further job steps from starting on the job.