### PR TITLE
Close the file descriptors in spawned processes

### DIFF
--- a/lib/flight_scheduler/batch_script_runner.rb
+++ b/lib/flight_scheduler/batch_script_runner.rb
@@ -84,7 +84,7 @@ module FlightScheduler
           FileUtils.mkdir_p File.dirname(@script.stderr_path)
 
           # Build the options hash
-          opts = { unsetenv_others: true }
+          opts = { unsetenv_others: true, close_others: true }
           if @script.stdout_path == @script.stderr_path
             opts.merge!({ [:out, :err] => @script.stdout_path })
           else


### PR DESCRIPTION
This prevents processes hanging onto the daemons port. This prevents
various issues with rebinding after restarts and leaving authenticated
connections open.

This gets a tad tricky with the `stepd` daemon as it requires the
websocket connection to communicate back to the control which port
it has started the TCP server on.

A work around is to hold onto the file descriptors until after the
message is sent