### PR TITLE
Terminate jobs when they exceed the their time limit

### DIFF
--- a/lib/flight_scheduler/batch_script.rb
+++ b/lib/flight_scheduler/batch_script.rb
@@ -70,11 +70,5 @@ module FlightScheduler
         FileUtils.chmod(0755, path)
       end
     end
-
-    def remove
-      Sync do
-        FileUtils.rm_rf(File.dirname(path))
-      end
-    end
   end
 end

--- a/lib/flight_scheduler/batch_script.rb
+++ b/lib/flight_scheduler/batch_script.rb
@@ -59,7 +59,7 @@ module FlightScheduler
       File.expand_path(@stdout_path, job.home_dir)
     end
 
-    def stderr_path 
+    def stderr_path
       File.expand_path(@stderr_path, job.home_dir)
     end
 

--- a/lib/flight_scheduler/batch_script_runner.rb
+++ b/lib/flight_scheduler/batch_script_runner.rb
@@ -108,7 +108,6 @@ module FlightScheduler
         @child_pid = nil
       ensure
         FlightScheduler.app.job_registry.remove_runner(@job.id, 'BATCH')
-        @script.remove
       end
     end
 

--- a/lib/flight_scheduler/batch_script_runner.rb
+++ b/lib/flight_scheduler/batch_script_runner.rb
@@ -112,12 +112,17 @@ module FlightScheduler
       end
     end
 
-    # Kills the associated subprocess
-    def cancel
+    def send_signal(sig)
       return unless @child_pid
-      Process.kill('-SIGTERM', @child_pid)
+      Async.logger.debug "Sending #{sig} to Process Group #{@child_pid}"
+      Process.kill(-Signal.list[sig], @child_pid)
     rescue Errno::ESRCH
       # NOOP - Don't worry if the process has already finished
+    end
+
+    # Kills the associated subprocess
+    def cancel
+      send_signal('TERM')
     end
   end
 end

--- a/lib/flight_scheduler/job.rb
+++ b/lib/flight_scheduler/job.rb
@@ -54,7 +54,7 @@ module FlightScheduler
       return false unless /\A[\w-]+\Z/.match? id
       return false unless env.is_a? Hash
       return false unless passwd
-      return false unless @time_out.nil? || (@time_out.is_a?(Integer) || @time_out >= 0)
+      return false unless @time_out.nil? || (@time_out.is_a?(Integer) && @time_out >= 0)
       true
     end
 

--- a/lib/flight_scheduler/job.rb
+++ b/lib/flight_scheduler/job.rb
@@ -124,7 +124,7 @@ module FlightScheduler
 
     # Must be called after adding to the registry
     def start_time_out_task
-      return if [nil, 0].include? @time_out
+      return if @time_out.nil?
       Async do |task|
         Async.logger.info "Job '#{id}' will start timing out in '#{@time_out}'"
         while FlightScheduler.app.job_registry.lookup_job(id)

--- a/lib/flight_scheduler/job.rb
+++ b/lib/flight_scheduler/job.rb
@@ -136,7 +136,7 @@ module FlightScheduler
               @timed_out_time = File.read(timed_out_path).to_i
               first = false
             else
-              Async.logger.error "Job Timed Out: #{id}"
+              Async.logger.info "Job Timed Out: #{id}"
               @timed_out_time = Process.clock_gettime(Process::CLOCK_MONOTONIC).to_i
               first = true
             end
@@ -171,7 +171,7 @@ module FlightScheduler
     end
 
     def send_signal(sig)
-      Async.logger.warn "Sending #{sig} to job: #{id}"
+      Async.logger.info "Sending #{sig} to job: #{id}"
       FlightScheduler.app.job_registry.lookup_runners(id).each do |_, runner|
         runner.send_signal(sig)
       end

--- a/lib/flight_scheduler/job.rb
+++ b/lib/flight_scheduler/job.rb
@@ -129,13 +129,23 @@ module FlightScheduler
         Async.logger.info "Job '#{id}' will start timing out in '#{@time_out}'"
         while FlightScheduler.app.job_registry.lookup_job(id)
           if @timed_out_time || time_out?
-            first = @timed_out_time ? false : true
-            @timed_out_time ||= Process.clock_gettime(Process::CLOCK_MONOTONIC).to_i
+            if @timed_out_time
+              first = false
+            elsif File.exists? timed_out_path
+              Async.logger.debug "Resuming time out for job: #{id}"
+              @timed_out_time = File.read(timed_out_path).to_i
+              first = false
+            else
+              Async.logger.error "Job Timed Out: #{id}"
+              @timed_out_time = Process.clock_gettime(Process::CLOCK_MONOTONIC).to_i
+              first = true
+            end
 
             if first
-              Async.logger.error "Job Timed Out: #{id}"
-              MessageSender.send(command: 'JOB_TIMED_OUT', job_id: id)
               send_signal("TERM")
+              File.write(timed_out_path, @timed_out_time)
+              MessageSender.send(command: 'JOB_TIMED_OUT', job_id: id)
+
               # Allow fast exiting runners to finalise quickly
               task.yield
             elsif (Process.clock_gettime(Process::CLOCK_MONOTONIC).to_i - @timed_out_time) > 90
@@ -153,6 +163,10 @@ module FlightScheduler
           end
           task.sleep 5
         end
+
+        if @timed_out_time
+          Async.logger.debug "Finished time out handling for job: #{id}"
+        end
       end
     end
 
@@ -164,6 +178,10 @@ module FlightScheduler
     end
 
     private
+
+    def timed_out_path
+      dirname.join(dirname, 'timed_out').to_path
+    end
 
     def env_path
       dirname.join(dirname, 'environment').to_path

--- a/lib/flight_scheduler/job_registry.rb
+++ b/lib/flight_scheduler/job_registry.rb
@@ -41,6 +41,7 @@ module FlightScheduler
     class DuplicateRunner < RuntimeError; end
     class UnknownJob < RuntimeError; end
     class DeallocatedJob < RuntimeError; end
+    class TimedOutJob < RuntimeError; end
 
     def initialize
       @jobs = Concurrent::Hash.new
@@ -56,6 +57,7 @@ module FlightScheduler
     def add_runner(job_id, runner_id, runner)
       data = @jobs[job_id]
       raise UnknownJob, job_id if data.nil?
+      raise TimedOutJob, job_id if data[:job].time_out?
       raise DeallocatedJob, job_id if data[:deallocated]
       runners = data[:runners]
       if runners[runner_id]

--- a/lib/flight_scheduler/job_registry.rb
+++ b/lib/flight_scheduler/job_registry.rb
@@ -52,6 +52,7 @@ module FlightScheduler
         raise DuplicateJob, job_id
       end
       @jobs[job_id] = { job: job, runners: Concurrent::Hash.new, deallocated: false }
+      job.start_time_out_task
     end
 
     def add_runner(job_id, runner_id, runner)

--- a/lib/flight_scheduler/job_step_runner.rb
+++ b/lib/flight_scheduler/job_step_runner.rb
@@ -106,12 +106,17 @@ module FlightScheduler
       end
     end
 
-    # Kills the associated subprocess
-    def cancel
+    def send_signal(sig)
       return unless @child_pid
-      Process.kill('-SIGTERM', @child_pid)
+      Async.logger.debug "Sending #{sig} to Process Group #{@child_pid}"
+      Process.kill(-Signal.list[sig], @child_pid)
     rescue Errno::ESRCH
       # NOOP - Don't worry if the process has already finished
+    end
+
+    # Kills the associated subprocess
+    def cancel
+      send_signal('TERM')
     end
   end
 end

--- a/lib/flight_scheduler/message_processor.rb
+++ b/lib/flight_scheduler/message_processor.rb
@@ -48,7 +48,6 @@ module FlightScheduler
             job.write
             FlightScheduler.app.job_registry.add_job(job.id, job)
             FlightScheduler.app.job_registry.save
-            job.start_time_out_task
 
           else
             raise JobValidationError, <<~ERROR.chomp

--- a/lib/flight_scheduler/message_processor.rb
+++ b/lib/flight_scheduler/message_processor.rb
@@ -39,14 +39,17 @@ module FlightScheduler
         job_id    = message[:job_id]
         env       = message[:environment]
         username  = message[:username]
+        time_out  = message[:time_limit]
 
         Async.logger.debug("Environment: #{env.map { |k, v| "#{k}=#{v}" }.join("\n")}")
         begin
-          job = FlightScheduler::Job.new(job_id, env, username)
+          job = FlightScheduler::Job.new(job_id, env, username, time_out)
           if job.valid?
             job.write
             FlightScheduler.app.job_registry.add_job(job.id, job)
             FlightScheduler.app.job_registry.save
+            job.start_time_out_task
+
           else
             raise JobValidationError, <<~ERROR.chomp
               An unexpected error has occurred! The job does not appear to be

--- a/spec/batch_script_spec.rb
+++ b/spec/batch_script_spec.rb
@@ -30,7 +30,7 @@ require 'securerandom'
 
 RSpec.describe FlightScheduler::BatchScript do
   let(:job) {
-    FlightScheduler::Job.new(SecureRandom.uuid, {}, Etc.getlogin)
+    FlightScheduler::Job.new(SecureRandom.uuid, {}, Etc.getlogin, 0)
   }
   let(:script_body) do
     <<~SCRIPT

--- a/spec/job_spec.rb
+++ b/spec/job_spec.rb
@@ -32,9 +32,10 @@ RSpec.describe FlightScheduler::Job do
   let(:id) { SecureRandom.uuid }
   let(:env) { {} }
   let(:username) { Etc.getlogin }
+  let(:timeout) { 0 }
 
   subject do
-    described_class.new(id, env, username)
+    described_class.new(id, env, username, timeout)
   end
 
   it { should be_valid }

--- a/spec/job_spec.rb
+++ b/spec/job_spec.rb
@@ -57,4 +57,10 @@ RSpec.describe FlightScheduler::Job do
 
     it { should_not be_valid }
   end
+
+  context 'with a negative timeout' do
+    let(:timeout) { -1 }
+
+    it { should_not be_valid }
+  end
 end


### PR DESCRIPTION
Each allocation may optional provide a `time_limit` which specifies how long it runs. Jobs which omit the `time_limit` are unaffected by the following changes.

When a `time_limit` is provided, the main daemon process starts a task for each allocation. This task does the following:
1. Checks if it is resuming a previous timed out task, and if not
2. Preforms an asynchronous sleep until the time out is reach OR the job is removed, then
3. Removed jobs are ignored, or
4. Sends `SIGTERM` to all processes within the process group and flags the job as timed out, then
5. It async waits for the job to finish removing it from the registry if required, or
6. After 90 seconds sends `SIGKILL` and repeats step 5

The `time_limit` and `created_time` have been added to the `job_registry/persistence` to allow the timelimit to resume after the daemon restarts. Unfortunately this does not work correctly at this point in time. The `JobRegistry` does not persist a record of the "runners" which is used as part of the timeout logic. This tricks the timeout into thinking all the "runners" have finished and exists immediately.

Other changes:
* Signals (`SIGTERM`/`SIGKILL`) are now sent to every process in the group and not just the leader
* The leader process (`stepd`, `batchd`) now "ignore" `SIGTERM` to allow them to communicate with the controller after their child processes have ended
* The `batch_script_runner` no longer removes the job script to prevent daemon restart issues. Instead it is removed when the job is deallocated.