### PR TITLE
Prevent timeout persistence blocking the daemon

### DIFF
--- a/lib/flight_scheduler/application.rb
+++ b/lib/flight_scheduler/application.rb
@@ -81,6 +81,9 @@ module FlightScheduler
 
     def run
       Async do |task|
+        # Starts all the pre-existing timeouts
+        job_registry.each_job(&:start_time_out_task)
+
         controller_url = FlightScheduler.app.config.controller_url
         endpoint = Async::HTTP::Endpoint.parse(controller_url)
         profiler.log

--- a/lib/flight_scheduler/job.rb
+++ b/lib/flight_scheduler/job.rb
@@ -127,7 +127,7 @@ module FlightScheduler
       return if @time_out.nil?
       Async do |task|
         remaining_time = @time_out + @created_time - Process.clock_gettime(Process::CLOCK_MONOTONIC)
-        Async.logger.info "Job '#{id}' will start timing out in '#{remaining_time.to_i}'"
+        Async.logger.info "Job '#{id}' will start timing out in '#{remaining_time.to_i}' seconds"
         while FlightScheduler.app.job_registry.lookup_job(id)
           if @timed_out_time || time_out?
             if @timed_out_time

--- a/lib/flight_scheduler/job.rb
+++ b/lib/flight_scheduler/job.rb
@@ -126,7 +126,8 @@ module FlightScheduler
     def start_time_out_task
       return if @time_out.nil?
       Async do |task|
-        Async.logger.info "Job '#{id}' will start timing out in '#{@time_out}'"
+        remaining_time = @time_out + @created_time - Process.clock_gettime(Process::CLOCK_MONOTONIC)
+        Async.logger.info "Job '#{id}' will start timing out in '#{remaining_time.to_i}'"
         while FlightScheduler.app.job_registry.lookup_job(id)
           if @timed_out_time || time_out?
             if @timed_out_time

--- a/lib/flight_scheduler/job_registry.rb
+++ b/lib/flight_scheduler/job_registry.rb
@@ -53,12 +53,11 @@ module FlightScheduler
       end
     end
 
-    def add_job(job_id, job, start_timeout: true)
+    def add_job(job_id, job)
       if @jobs[job_id]
         raise DuplicateJob, job_id
       end
       @jobs[job_id] = { job: job, runners: Concurrent::Hash.new, deallocated: false }
-      job.start_time_out_task if start_timeout
     end
 
     def add_runner(job_id, runner_id, runner)
@@ -115,7 +114,7 @@ module FlightScheduler
       data.each do |hash|
         job = Job.from_serialized_hash(hash)
         if job.valid?
-          add_job(job.id, job, start_timeout: false)
+          add_job(job.id, job)
         else
           Async.logger.warn("Invalid job loaded: #{job.inspect}")
         end

--- a/lib/flight_scheduler/job_registry.rb
+++ b/lib/flight_scheduler/job_registry.rb
@@ -47,12 +47,18 @@ module FlightScheduler
       @jobs = Concurrent::Hash.new
     end
 
-    def add_job(job_id, job)
+    def each_job
+      @jobs.each do |_, job|
+        yield job[:job] if block_given?
+      end
+    end
+
+    def add_job(job_id, job, start_timeout: true)
       if @jobs[job_id]
         raise DuplicateJob, job_id
       end
       @jobs[job_id] = { job: job, runners: Concurrent::Hash.new, deallocated: false }
-      job.start_time_out_task
+      job.start_time_out_task if start_timeout
     end
 
     def add_runner(job_id, runner_id, runner)
@@ -109,7 +115,7 @@ module FlightScheduler
       data.each do |hash|
         job = Job.from_serialized_hash(hash)
         if job.valid?
-          add_job(job.id, job)
+          add_job(job.id, job, start_timeout: false)
         else
           Async.logger.warn("Invalid job loaded: #{job.inspect}")
         end

--- a/lib/flight_scheduler/message_processor.rb
+++ b/lib/flight_scheduler/message_processor.rb
@@ -50,6 +50,7 @@ module FlightScheduler
             job.write
             FlightScheduler.app.job_registry.add_job(job.id, job)
             FlightScheduler.app.job_registry.save
+            job.start_time_out_task
 
           else
             raise JobValidationError, <<~ERROR.chomp


### PR DESCRIPTION
Previously the daemon would be blocked after restarting a timeout. This is because it would create an `Async` reactor before the main loop. This reactor then hangs until the timeouts complete.

Instead the persisted timeouts must be restarted in the main `Async` loop.